### PR TITLE
Remove wallet name & copayer names from templates

### DIFF
--- a/en/new_copayer.plain
+++ b/en/new_copayer.plain
@@ -1,5 +1,5 @@
 {{subjectPrefix}}New copayer
-A new copayer just joined your wallet {{walletName}}.
+A new copayer just joined your wallet.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/en/new_copayers.html
+++ b/en/new_copayers.html
@@ -135,7 +135,7 @@
         <img src="https://copay.io/images/email/new-copayer.png" alt="New Copayer" style="display: inline-block; vertical-align: middle; margin-right: 0.5rem;" width="35">
         <span> New copayer</span>
       </h3>
-      <p style="color: #7A8C9E; font-size: 15px">A new copayer just joined your wallet <strong>{{walletName}}.</strong> </p>
+      <p style="color: #7A8C9E; font-size: 15px">A new copayer just joined your wallet.</p>
     </div>
     <p style="color: #B4C0CB; font-size: 0.7rem; margin-top: 1.5rem; line-height: 150%">
       <span>3405 Piedmont Rd NE, Atlanta - BitPay </span> <br>

--- a/en/new_incoming_tx.html
+++ b/en/new_incoming_tx.html
@@ -135,7 +135,7 @@
         <img src="https://copay.io/images/email/payment-received.png" alt="Payment Received" style="display: inline-block; vertical-align: middle; margin-right: 0.5rem;" width="35">
         <span>New payment received</span>
       </h3>
-      <p style="color: #7A8C9E; font-size: 15px">A payment of <strong>{{amount}}</strong> has been received into your wallet <strong>{{walletName}}.</strong> </p>
+      <p style="color: #7A8C9E; font-size: 15px">A payment of <strong>{{amount}}</strong> has been received into your wallet. </p>
       {{#urlForTx}}<a style="font-size: 0.8rem;" href="{{urlForTx}}"> See it on the Blockchain </a>{{/urlForTx}}
     </div>
     <p style="color: #B4C0CB; font-size: 0.7rem; margin-top: 1.5rem; line-height: 150%">

--- a/en/new_incoming_tx.plain
+++ b/en/new_incoming_tx.plain
@@ -1,5 +1,5 @@
 {{subjectPrefix}}New payment received
-A payment of {{amount}} has been received into your wallet {{walletName}}.
+A payment of {{amount}} has been received into your wallet.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/en/new_outgoing_tx.html
+++ b/en/new_outgoing_tx.html
@@ -135,7 +135,7 @@
         <img src="https://copay.io/images/email/payment-sent.png" alt="Payment Sent" style="display: inline-block; vertical-align: middle; margin-right: 0.5rem;" width="35">
         <span>Payment sent</span>
       </h3>
-      <p style="color: #7A8C9E; font-size: 15px">A Payment of <strong> {{amount}} </strong> has been sent from your wallet. <strong>{{walletName}}.</strong> </p>
+      <p style="color: #7A8C9E; font-size: 15px">A Payment of <strong> {{amount}} </strong> has been sent from your wallet. </p>
       {{#urlForTx}}<a style="font-size: 0.8rem;" href="{{urlForTx}}"> See it on the Blockchain </a>{{/urlForTx}}
     </div>
     <p style="color: #B4C0CB; font-size: 0.7rem; margin-top: 1.5rem; line-height: 150%">

--- a/en/new_outgoing_tx.plain
+++ b/en/new_outgoing_tx.plain
@@ -1,5 +1,5 @@
 {{subjectPrefix}}Payment sent
-A Payment of {{amount}} has been sent from your wallet {{walletName}}.
+A Payment of {{amount}} has been sent from your wallet.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/en/new_tx_proposal.html
+++ b/en/new_tx_proposal.html
@@ -135,7 +135,7 @@
         <img src="https://copay.io/images/email/new-proposal.png" alt="New Proposal Pending" style="display: inline-block; vertical-align: middle; margin-right: 0.5rem;" width="35">
         <span>New payment proposal</span>
       </h3>
-      <p style="color: #7A8C9E; font-size: 15px">A new payment proposal has been created in your wallet <strong>{{walletName}}.</strong> by <strong> {{copayerName}}. </strong> </p>
+      <p style="color: #7A8C9E; font-size: 15px">A new payment proposal has been created. </p>
     </div>
     <p style="color: #B4C0CB; font-size: 0.7rem; margin-top: 1.5rem; line-height: 150%">
       <span>3405 Piedmont Rd NE, Atlanta - BitPay </span> <br>

--- a/en/new_tx_proposal.plain
+++ b/en/new_tx_proposal.plain
@@ -1,5 +1,5 @@
 {{subjectPrefix}}New payment proposal
-A new payment proposal has been created in your wallet {{walletName}} by {{copayerName}}.
+A new payment proposal has been created.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/en/txp_finally_rejected.html
+++ b/en/txp_finally_rejected.html
@@ -135,7 +135,7 @@
         <img src="https://copay.io/images/email/proposal-rejected.png" alt="Payment Rejected" style="display: inline-block; vertical-align: middle; margin-right: 0.5rem;" width="35">
         <span>Payment proposal rejected</span>
       </h3>
-      <p style="color: #7A8C9E; font-size: 15px">A payment proposal in your wallet <strong> {{walletName}} </strong> has been rejected by <strong>{{rejectorsNames}}.</strong> </p>
+      <p style="color: #7A8C9E; font-size: 15px">A payment proposal has been rejected. </p>
     </div>
     <p style="color: #B4C0CB; font-size: 0.7rem; margin-top: 1.5rem; line-height: 150%">
       <span>3405 Piedmont Rd NE, Atlanta - BitPay </span> <br>

--- a/en/txp_finally_rejected.plain
+++ b/en/txp_finally_rejected.plain
@@ -1,5 +1,5 @@
 {{subjectPrefix}}Payment proposal rejected
-A payment proposal in your wallet {{walletName}} has been rejected by {{rejectorsNames}}.
+A payment proposal has been rejected.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/en/wallet_complete.html
+++ b/en/wallet_complete.html
@@ -136,7 +136,7 @@
         <img src="https://copay.io/images/email/wallet-complete.png" alt="Wallet Complete" style="display: inline-block; vertical-align: middle; margin-right: 0.5rem;" width="35">
         <span>Wallet complete</span>
       </h3>
-      <p style="color: #7A8C9E; font-size: 15px">Your wallet <strong> {{walletName}}</strong> is complete. </p>
+      <p style="color: #7A8C9E; font-size: 15px">Your wallet is complete. </p>
     </div>
     <p style="color: #B4C0CB; font-size: 0.7rem; margin-top: 1.5rem; line-height: 150%">
       <span>3405 Piedmont Rd NE, Atlanta - BitPay </span> <br>

--- a/en/wallet_complete.plain
+++ b/en/wallet_complete.plain
@@ -1,5 +1,5 @@
 {{subjectPrefix}}Wallet complete
-Your wallet {{walletName}} is complete.
+Your wallet is complete.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/es/new_copayer.plain
+++ b/es/new_copayer.plain
@@ -1,5 +1,5 @@
 {{subjectPrefix}}Nuevo copayer
-Un nuevo copayer ha ingresado a su monedero {{walletName}}.
+Un nuevo copayer ha ingresado a su monedero.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/es/new_copayers.html
+++ b/es/new_copayers.html
@@ -135,7 +135,7 @@
         <img src="https://copay.io/images/email/new-copayer.png" alt="New Copayer" style="display: inline-block; vertical-align: middle; margin-right: 0.5rem;" width="35">
         <span> Nuevo copayer </span>
       </h3>
-      <p style="color: #7A8C9E; font-size: 15px"> Un nuevo copayer ha ingresado a su monedero <strong>{{walletName}}.</strong> </p>
+      <p style="color: #7A8C9E; font-size: 15px"> Un nuevo copayer ha ingresado a su monedero. </p>
     </div>
     <p style="color: #B4C0CB; font-size: 0.7rem; margin-top: 1.5rem; line-height: 150%">
       <span>3405 Piedmont Rd NE, Atlanta - BitPay </span> <br>

--- a/es/new_incoming_tx.html
+++ b/es/new_incoming_tx.html
@@ -135,7 +135,7 @@
         <img src="https://copay.io/images/email/payment-received.png" alt="Payment Received" style="display: inline-block; vertical-align: middle; margin-right: 0.5rem;" width="35">
         <span>Nuevo pago recibido</span>
       </h3>
-      <p style="color: #7A8C9E; font-size: 15px">Un pago de <strong>{{amount}}</strong> fue recibido en su monedero <strong>{{walletName}}.</strong> </p>
+      <p style="color: #7A8C9E; font-size: 15px">Un pago de <strong>{{amount}}</strong> fue recibido en su monedero. </p>
       {{#urlForTx}}<a style="font-size: 0.8rem;" href="{{urlForTx}}"> See it on the Blockchain </a>{{/urlForTx}}
     </div>
     <p style="color: #B4C0CB; font-size: 0.7rem; margin-top: 1.5rem; line-height: 150%">

--- a/es/new_incoming_tx.plain
+++ b/es/new_incoming_tx.plain
@@ -1,5 +1,5 @@
 {{subjectPrefix}}Nuevo pago recibido
-Un pago de {{amount}} fue recibido en su monedero {{walletName}}.
+Un pago de {{amount}} fue recibido en su monedero.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/es/new_outgoing_tx.html
+++ b/es/new_outgoing_tx.html
@@ -135,7 +135,7 @@
         <img src="https://copay.io/images/email/payment-sent.png" alt="Payment Sent" style="display: inline-block; vertical-align: middle; margin-right: 0.5rem;" width="35">
         <span>Pago enviado</span>
       </h3>
-      <p style="color: #7A8C9E; font-size: 15px">Un pago de <strong> {{amount}} </strong> ha sido enviado de su monedero <strong>{{walletName}}.</strong> </p>
+      <p style="color: #7A8C9E; font-size: 15px">Un pago de <strong> {{amount}} </strong> ha sido enviado de su monedero. </p>
       {{#urlForTx}}<a style="font-size: 0.8rem;" href="{{urlForTx}}"> See it on the Blockchain </a>{{/urlForTx}}
     </div>
     <p style="color: #B4C0CB; font-size: 0.7rem; margin-top: 1.5rem; line-height: 150%">

--- a/es/new_outgoing_tx.plain
+++ b/es/new_outgoing_tx.plain
@@ -1,5 +1,5 @@
 {{subjectPrefix}}Pago enviado
-Un pago de {{amount}} ha sido enviado de su monedero {{walletName}}.
+Un pago de {{amount}} ha sido enviado de su monedero.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/es/new_tx_proposal.html
+++ b/es/new_tx_proposal.html
@@ -135,7 +135,7 @@
         <img src="https://copay.io/images/email/new-proposal.png" alt="New Proposal Pending" style="display: inline-block; vertical-align: middle; margin-right: 0.5rem;" width="35">
         <span>Nueva propuesta de pago</span>
       </h3>
-      <p style="color: #7A8C9E; font-size: 15px">Una nueva propuesta de pago ha sido creada en su monedero <strong>{{walletName}}.</strong> por <strong> {{copayerName}}. </strong> </p>
+      <p style="color: #7A8C9E; font-size: 15px">Una nueva propuesta de pago ha sido creada. </p>
     </div>
     <p style="color: #B4C0CB; font-size: 0.7rem; margin-top: 1.5rem; line-height: 150%">
       <span>3405 Piedmont Rd NE, Atlanta - BitPay </span> <br>

--- a/es/new_tx_proposal.plain
+++ b/es/new_tx_proposal.plain
@@ -1,5 +1,5 @@
 {{subjectPrefix}}Nueva propuesta de pago
-Una nueva propuesta de pago ha sido creada en su monedero {{walletName}} por {{copayerName}}.
+Una nueva propuesta de pago ha sido creada.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/es/txp_finally_rejected.html
+++ b/es/txp_finally_rejected.html
@@ -135,7 +135,7 @@
         <img src="https://copay.io/images/email/proposal-rejected.png" alt="Payment Rejected" style="display: inline-block; vertical-align: middle; margin-right: 0.5rem;" width="35">
         <span>Propuesta de pago rechazada</span>
       </h3>
-      <p style="color: #7A8C9E; font-size: 15px">Una propuesta de pago en su monedero <strong> {{walletName}} </strong> ha sido rechazada por <strong>{{rejectorsNames}}.</strong> </p>
+      <p style="color: #7A8C9E; font-size: 15px">Una propuesta de pago ha sido rechazada. </p>
     </div>
     <p style="color: #B4C0CB; font-size: 0.7rem; margin-top: 1.5rem; line-height: 150%">
       <span>3405 Piedmont Rd NE, Atlanta - BitPay </span> <br>

--- a/es/txp_finally_rejected.plain
+++ b/es/txp_finally_rejected.plain
@@ -1,5 +1,5 @@
 {{subjectPrefix}}Propuesta de pago rechazada
-Una propuesta de pago en su monedero {{walletName}} ha sido rechazada por {{rejectorsNames}}.
+Una propuesta de pago ha sido rechazada.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/es/wallet_complete.html
+++ b/es/wallet_complete.html
@@ -136,7 +136,7 @@
         <img src="https://copay.io/images/email/wallet-complete.png" alt="Wallet Complete" style="display: inline-block; vertical-align: middle; margin-right: 0.5rem;" width="35">
         <span>Monedero completo</span>
       </h3>
-      <p style="color: #7A8C9E; font-size: 15px">Su monedero <strong> {{walletName}}</strong> está completo. </p>
+      <p style="color: #7A8C9E; font-size: 15px">Su monedero está completo. </p>
     </div>
     <p style="color: #B4C0CB; font-size: 0.7rem; margin-top: 1.5rem; line-height: 150%">
       <span>3405 Piedmont Rd NE, Atlanta - BitPay </span> <br>

--- a/es/wallet_complete.plain
+++ b/es/wallet_complete.plain
@@ -1,5 +1,5 @@
 {{subjectPrefix}}Monedero completo
-Su monedero {{walletName}} está completo.
+Su monedero está completo.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/fr/new_copayer.plain
+++ b/fr/new_copayer.plain
@@ -1,5 +1,5 @@
 {{subjectPrefix}}Nouveau copayer
-Un nouveau copayer vient de rejoindre votre portefeuille {{walletName}}.
+Un nouveau copayer vient de rejoindre votre portefeuille.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/fr/new_incoming_tx.plain
+++ b/fr/new_incoming_tx.plain
@@ -1,5 +1,5 @@
 {{subjectPrefix}}Nouveau paiement reçu
-Un paiement de {{amount}} a été reçu dans votre portefeuille {{walletName}}.
+Un paiement de {{amount}} a été reçu dans votre portefeuille.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/fr/new_outgoing_tx.plain
+++ b/fr/new_outgoing_tx.plain
@@ -1,5 +1,5 @@
 {{subjectPrefix}}Paiement envoyé
-Un paiement de {{amount}} a été envoyé de votre portefeuille {{walletName}}.
+Un paiement de {{amount}} a été envoyé de votre portefeuille.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/fr/new_tx_proposal.plain
+++ b/fr/new_tx_proposal.plain
@@ -1,5 +1,5 @@
 {{subjectPrefix}}Nouvelle proposition de paiement
-Une nouvelle proposition de paiement a été créée dans votre portefeuille {{walletName}} par {{copayerName}}.
+Une nouvelle proposition de paiement a été créée.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/fr/txp_finally_rejected.plain
+++ b/fr/txp_finally_rejected.plain
@@ -1,5 +1,5 @@
 {{subjectPrefix}}Proposition de paiement rejetée
-Une proposition de paiement dans votre portefeuille {{walletName}} a été rejetée par {{rejectorsNames}}.
+Une proposition de paiement a été rejetée.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/fr/wallet_complete.plain
+++ b/fr/wallet_complete.plain
@@ -1,5 +1,5 @@
 {{subjectPrefix}}Portefeuille terminé
-Votre portefeuille {{walletName}} est terminé.
+Votre portefeuille est terminé.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/ja/new_copayer.plain
+++ b/ja/new_copayer.plain
@@ -1,5 +1,5 @@
-{{subjectPrefix}}ウォレットメンバー参加の知らせ
-「{{walletName}}」のウォレットに新しいメンバーが加わりました。
+{{subjectPrefix}}New copayer
+A new copayer just joined your wallet.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/ja/new_incoming_tx.plain
+++ b/ja/new_incoming_tx.plain
@@ -1,5 +1,5 @@
-{{subjectPrefix}}着金確認の知らせ
-{{amount}} のビットコインがウォレット「{{walletName}}」に着金しました。
+{{subjectPrefix}}New payment received
+A payment of {{amount}} has been received into your wallet.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/ja/new_outgoing_tx.plain
+++ b/ja/new_outgoing_tx.plain
@@ -1,5 +1,5 @@
-{{subjectPrefix}}送金のお知らせ
-{{amount}}のビットコインがウォレット「{{walletName}}」から送金されました。
+{{subjectPrefix}}Payment sent
+A Payment of {{amount}} has been sent from your wallet.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/ja/new_tx_proposal.plain
+++ b/ja/new_tx_proposal.plain
@@ -1,5 +1,5 @@
-{{subjectPrefix}}送金の新規提案のお知らせ
-「{{walletName}}」のウォレットにおいて {{copayerName}} さんが送金の提案をしました。
+{{subjectPrefix}}New payment proposal
+A new payment proposal has been created.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/ja/txp_finally_rejected.plain
+++ b/ja/txp_finally_rejected.plain
@@ -1,5 +1,5 @@
-{{subjectPrefix}}送金提案の却下のお知らせ
-「{{walletName}}」のウォレットにおいて {{rejectorsNames}} さんが送金の提案を却下しました。
+{{subjectPrefix}}Payment proposal rejected
+A payment proposal has been rejected.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay

--- a/ja/wallet_complete.plain
+++ b/ja/wallet_complete.plain
@@ -1,5 +1,5 @@
-{{subjectPrefix}}ウォレット作成完了
-あなたの新しいウォレット「{{walletName}}」が完成されました。
+{{subjectPrefix}}Wallet complete
+Your wallet is complete.
 
 --
 3405 Piedmont Rd NE, Atlanta - BitPay


### PR DESCRIPTION
Due to Copay no longer sending these fields in cleartext to BWS.
